### PR TITLE
Extend configuration with JBinFol

### DIFF
--- a/qjide.cfg
+++ b/qjide.cfg
@@ -55,6 +55,10 @@ ConsoleFontSize = 16
 JInsFol = '/Users/martin/J804'       # On my mac
 #JInsFol = '/home/martin/J701'          # On my linux box
 
+# J Binaries Folder (absolute or relative (to JInsFol) path)
+JBinFol = 'bin'
+#JBinFol = '/usr/lib/j8/bin'            # On Arch Linux (if installed by pacman)
+
 # J Multi Session
 # True  = Each web connection (ip address) use its own J instance
 # False = All web connections (ip address) share the same J instance

--- a/qjide.py
+++ b/qjide.py
@@ -231,7 +231,7 @@ class J():
       self.JOutStr = ''
 
       # J Binaries Folder (absolute or relative (to JInsFol) path)
-      self.JBinFol = 'bin'
+      self.JBinFol = JBinFol
 
       # J Profile (absolute or relative (to JBinFol) path)
       self.JProFil = 'profile.ijs'


### PR DESCRIPTION
Some Linux distributions (e.g. Arch Linux) may split J binaries folder
and user folders. This commit adds JBinFol variable to the configuration
file.